### PR TITLE
Configure PostGIS in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ services:
 
 addons:
   postgresql: '9.6'
+  apt:
+    packages:
+    - postgresql-9.6-postgis-2.3
 
 env:
   global:
@@ -24,8 +27,6 @@ env:
     - CFG_ALLOWED_HOSTS=localhost
 
 before_script:
-  - sudo apt-get install -y binutils libproj-dev gdal-bin libgeoip1 python-gdal
-  - sudo apt-get install -y postgresql-9.6-postgis-2.4
   - psql -c 'create database test_db;' -U postgres
   - psql -c 'create extension postgis;' -U postgres -d test_db
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     # uWSGI needs mime-support to serve static files
     # with the correct content-type header
     mime-support \
+    binutils libproj-dev gdal-bin libgeoip1 python-gdal \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.1/ref/contrib/gis/install/geolibs/#gdaltrouble

https://docs.djangoproject.com/en/2.1/ref/contrib/gis/install/#libsettings

https://docs.djangoproject.com/en/2.1/ref/contrib/gis/install/geolibs/#gdal
https://docs.djangoproject.com/en/2.1/ref/contrib/gis/install/geolibs/#installing-geospatial-libraries
https://docs.travis-ci.com/user/database-setup/#using-postgis

Library environment settings
By far, the most common problem when installing GeoDjango is that the external shared libraries (e.g., for GEOS and GDAL) cannot be located. Typically, the cause of this problem is that the operating system isn’t aware of the directory where the libraries built from source were installed.

In general, the library path may be set on a per-user basis by setting an environment variable, or by configuring the library path for the entire system.

LD_LIBRARY_PATH environment variable
A user may set this environment variable to customize the library paths they want to use. The typical library directory for software built from source is /usr/local/lib. Thus, /usr/local/lib needs to be included in the LD_LIBRARY_PATH variable. For example, the user could place the following in their bash profile:
```
export LD_LIBRARY_PATH=/usr/local/lib
```

Troubleshooting
Can’t find GDAL library
When GeoDjango can’t find the GDAL library, configure your Library environment settings or set GDAL_LIBRARY_PATH in your settings.

GDAL_LIBRARY_PATH
If your GDAL library is in a non-standard location, or you don’t want to modify the system’s library path then the GDAL_LIBRARY_PATH setting may be added to your Django settings file with the full path to the GDAL library. For example:
```
GDAL_LIBRARY_PATH = '/home/sue/local/lib/libgdal.so'
```